### PR TITLE
Update to KSampler SDXL (Eff.)

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -545,7 +545,7 @@ class TSC_KSampler:
 
                     # Perform base model sampling
                     add_noise = return_with_leftover_noise = True
-                    samples = KSamplerAdvanced().sample(model, add_noise, seed, steps, cfg, sampler_name, scheduler,
+                    samples = KSamplerAdvanced().sample(model, add_noise, seed, end_at_step, cfg, sampler_name, scheduler,
                                                         positive, negative, latent_image, start_at_step, end_at_step,
                                                         return_with_leftover_noise, denoise=1.0)[0]
 


### PR DESCRIPTION
Changed the total number of steps when using the base model from steps to refine at step.  There are two reasons I believe this is beneficial.   1) It allows EfficiencyNode users to duplicate exact image results they would get by using SDXL base and SDXL refiner separately using base comfyui.  2)   It allows for iteration on an exact base image with a refiner rather than the base image changing when you increase the number of steps to add refiner steps on the end.

@jags111 I couldn't find a working invite to a discord channel, but I'd be happy to join and discuss this change further with you.