### PR TITLE
Ensure to check a widget's prototype for `value` property descriptor.

### DIFF
--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -610,6 +610,9 @@ app.registerExtension({
 
             // Store the original descriptor if it exists
             let originalDescriptor = Object.getOwnPropertyDescriptor(w, 'value');
+            if (!originalDescriptor) {
+                originalDescriptor = Object.getOwnPropertyDescriptor(w.constructor.prototype, 'value');
+            }
 
             widgetLogic(node, w);
 


### PR DESCRIPTION
This fixes cases where the widget is not a plain object, but a class instance with `value` getters/setters.