### PR TITLE
Fix overaggressive caching for latents with the same pixel density but different dimensions, minor fix for headless mode

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -134,7 +134,8 @@ class TSC_EfficientLoader:
                         ascore=None, prompt=None, my_unique_id=None, loader_type="regular"):
 
         # Clean globally stored objects
-        globals_cleanup(prompt)
+        if prompt:
+            globals_cleanup(prompt)
 
         # Create Empty Latent
         latent = torch.zeros([batch_size, 4, empty_latent_height // 8, empty_latent_width // 8]).cpu()
@@ -722,7 +723,8 @@ class TSC_KSampler:
 
         # ---------------------------------------------------------------------------------------------------------------
         # Clean globally stored objects of non-existant nodes
-        globals_cleanup(prompt)
+        if prompt:
+            globals_cleanup(prompt)
 
         # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         # If not XY Plotting

--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -518,6 +518,7 @@ class TSC_KSampler:
                 # ------------------------------------------------------------------------------------------------------
                 # Store run parameters as strings. Load previous stored samples if all parameters match.
                 latent_image_hash = tensor_to_hash(latent_image["samples"])
+                latent_image_shape = latent_image["samples"].shape
                 positive_hash = tensor_to_hash(positive[0][0])
                 negative_hash = tensor_to_hash(negative[0][0])
                 refiner_positive_hash = tensor_to_hash(refiner_positive[0][0]) if refiner_positive is not None else None
@@ -528,7 +529,7 @@ class TSC_KSampler:
                                     else [original_model_str]
 
                 parameters = [model_identifier] + [seed, steps, cfg, sampler_name, scheduler, positive_hash, negative_hash,
-                                                  latent_image_hash, denoise, sampler_type, add_noise, start_at_step,
+                                                  latent_image_hash, latent_image_shape, denoise, sampler_type, add_noise, start_at_step,
                                                   end_at_step, return_with_leftover_noise, refiner_model, refiner_positive_hash,
                                                   refiner_negative_hash, rng_source, cfg_denoiser, add_seed_noise, m_seed, m_weight]
 


### PR DESCRIPTION
Currently TSC_KSampler.sample caches sampler results using a variety of input keys including the hash of the input latent image. However, the key does not include the latent's shape. Back to back generations with empty latents of contrasting portrait/landscape shapes but equal latent pixel counts appear to result in a false positive cache hit if all other parameters are held the same.

![image](https://github.com/user-attachments/assets/fdc44a60-d7ef-4497-a6c5-78f35be2b1dd)
![image](https://github.com/user-attachments/assets/eb5a4196-954d-4118-951d-70d222c160bc)

Additionally, a guard has been added to calls to globals_cleanup() to ensure a prompt object exists - when using the node headlessly via pydn/ComfyUI-to-Python-Extension calls to globals_cleanup will crash the server. My apologies for bundling these.