### PR TITLE
Changed min values allowed for Y in TSC_XYplot_LoRA_Plot to include negative values.

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -3031,8 +3031,8 @@ class TSC_XYplot_LoRA_Plot:
                 "X_first_value": ("FLOAT", {"default": 0.0, "min": 0.00, "max": 10.0, "step": 0.01}),
                 "X_last_value": ("FLOAT", {"default": 1.0, "min": 0.00, "max": 10.0, "step": 0.01}),
                 "Y_batch_count": ("INT", {"default": XYPLOT_DEF, "min": 0, "max": XYPLOT_LIM}),
-                "Y_first_value": ("FLOAT", {"default": 0.0, "min": 0.00, "max": 10.0, "step": 0.01}),
-                "Y_last_value": ("FLOAT", {"default": 1.0, "min": 0.00, "max": 10.0, "step": 0.01}),},
+                "Y_first_value": ("FLOAT", {"default": 0.0, "min": -10.00, "max": 10.0, "step": 0.01}),
+                "Y_last_value": ("FLOAT", {"default": 1.0, "min": -10.00, "max": 10.0, "step": 0.01}),},
             "optional": {"lora_stack": ("LORA_STACK",)}
         }
 


### PR DESCRIPTION
"XY Input: LoRA Plot" currently doesn't allow negative strengths. I believe this is a bug, there's no reason to prevent negative values to be used with LoRAs that support them.

It's an easy fix, I already tested it locally, and it seems to work correctly.