### PR TITLE
Quick patch for the LoRA Stacker node

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -300,11 +300,11 @@ class TSC_LoRA_Stacker:
         inputs = {
             "required": {
                 "input_mode": (cls.modes,),
-                "lora_count": ("INT", {"default": 3, "min": 0, "max": 50, "step": 1}),
+                "lora_count": ("INT", {"default": 3, "min": 0, "max": 3, "step": 1}),
             }
         }
 
-        for i in range(1, 50):
+        for i in range(1, 3):
             inputs["required"][f"lora_name_{i}"] = (loras,)
             inputs["required"][f"lora_wt_{i}"] = ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01})
             inputs["required"][f"model_str_{i}"] = ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01})

--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -304,7 +304,7 @@ class TSC_LoRA_Stacker:
             }
         }
 
-        for i in range(1, 3):
+        for i in range(1, 4):
             inputs["required"][f"lora_name_{i}"] = (loras,)
             inputs["required"][f"lora_wt_{i}"] = ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01})
             inputs["required"][f"model_str_{i}"] = ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01})


### PR DESCRIPTION
The latest ComfyUI frontend update broke the LoRA Stacker node. What I am proposing in this PR is not a permanent solution but a temporary patch, one that just restricts the node to a much more streamlined three LoRA system instead of fifty, which prevents it from becoming an unwieldy, tall node for the time being. Not intended to be a permanent solution as I only changed two values in the code, and I'm sure there will be a way to make widgets appear and disappear like what was possible before, but for now, this will probably do.

NOTE: just edited it again, the screenshot is slightly less accurate now as now there are three LoRA sections instead of 2, didn't catch this the first time.
![2025-04-20_20-05](https://github.com/user-attachments/assets/dc655e55-f1f1-4a10-bf71-4bc9c4b988de)
