### PR TITLE
Quick-fix for widgethider.js for recent ComfyUI version

### DIFF
--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -8,7 +8,7 @@ const findWidgetByName = (node, name) => {
 };
 
 const doesInputWithNameExist = (node, name) => {
-    return node.inputs ? node.inputs.some((input) => input.name === name) : false;
+    return false;
 };
 
 const HIDDEN_TAG = "tschide";


### PR DESCRIPTION
It seems that a recent update to ComfyUI removed the ability to convert widgets to inputs. Instead, all widgets automatically have a corresponding input added to the node by default.
The widgethider.js script is responsible for hiding widgets that are not supposed to be visible, but ignores widgets that have a corresponding input, as they used to be invisible by default after having been converted to an input. To fix this issue I simply deactivated this check.
While this solution is not perfect, there are so many issues with this file that it doesn't really matter at this point. I might propose a rewritten version of the widgethider script at some point in the future.

This should resolve #311 and #313.