### PR TITLE
Bug Fixes widgethider.js

### DIFF
--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -8,7 +8,8 @@ const findWidgetByName = (node, name) => {
 };
 
 const doesInputWithNameExist = (node, name) => {
-    return node.inputs ? node.inputs.some((input) => input.name === name) : false;
+    // return node.inputs ? node.inputs.some((input) => input.name === name) : false;
+    return false;
 };
 
 const HIDDEN_TAG = "tschide";
@@ -605,7 +606,9 @@ function handleXYInputControlNetPlotPlotType(node, widget) {
 app.registerExtension({
     name: "efficiency.widgethider",
     nodeCreated(node) {
+        if (!nodeWidgetHandlers[node.comfyClass]) return;
         for (const w of node.widgets || []) {
+            if (!nodeWidgetHandlers[node.comfyClass][w.name]) continue;
             let widgetValue = w.value;
 
             // Store the original descriptor if it exists


### PR DESCRIPTION
Bug Fixes
Resolved "Cannot redefine property" error
→ This was a critical issue that occurs with ComfyUI frontend version 1.17 and above. It prevents not only this custom node but also other custom nodes from functioning properly. The fix restores compatibility with newer frontend versions.

Fixed the issue where the LoRA Stacker widget was not working
→ The fix was adapted from [jags111/efficiency-nodes-comfyui#315](https://github.com/jags111/efficiency-nodes-comfyui/pull/315).
