### PR TITLE
Restore LoRA Stacker Node

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -306,11 +306,11 @@ class TSC_LoRA_Stacker:
         inputs = {
             "required": {
                 "input_mode": (cls.modes,),
-                "lora_count": ("INT", {"default": 3, "min": 0, "max": 3, "step": 1}),
+                "lora_count": ("INT", {"default": 3, "min": 0, "max": 50, "step": 1}),
             }
         }
 
-        for i in range(1, 4):
+        for i in range(1, 51):
             inputs["required"][f"lora_name_{i}"] = (loras,)
             inputs["required"][f"lora_wt_{i}"] = ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01})
             inputs["required"][f"model_str_{i}"] = ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01})


### PR DESCRIPTION
Restore LoRA Stacker Node
Last month, due to a front-end update on Comfyui, widgethider.js broke. Now there are https://github.com/jags111/efficiency-nodes-comfyui/pull/321 Repairs have been made, therefore please restore from https://github.com/jags111/efficiency-nodes-comfyui/pull/314 The damage caused to the node itself.