### PR TITLE
优化encode_token_weights函数以保持CLIP选项与ComfyUI核心编码路径一致

### DIFF
--- a/py/bnk_adv_encode.py
+++ b/py/bnk_adv_encode.py
@@ -222,10 +222,14 @@ def encode_token_weights_l(model, token_weight_pairs):
     return l_out, None
 
 def encode_token_weights(model, token_weight_pairs, encode_func):
+    # Keep CLIP options aligned with ComfyUI's core encode path so token
+    # tensors are created on the same device as the active text encoder pass.
+    model.cond_stage_model.reset_clip_options()
     if model.layer_idx is not None:
         model.cond_stage_model.set_clip_options({"layer": model.layer_idx})
     
     model_management.load_model_gpu(model.patcher)
+    model.cond_stage_model.set_clip_options({"execution_device": model.patcher.load_device})
     return encode_func(model.cond_stage_model, token_weight_pairs)
 
 def prepareXL(embs_l, embs_g, pooled, clip_balance):


### PR DESCRIPTION
fix bug when I use  `-s ComfyUI\main.py --windows-standalone-build --fast` launch ComfyUI
```
2026-02-19T18:15:58.866561 - got prompt
2026-02-19T18:15:58.883581 - Requested to load SDXLClipModel
2026-02-19T18:15:58.909517 - Model SDXLClipModel prepared for dynamic VRAM loading. 1560MB Staged. 264 patches attached.
2026-02-19T18:15:58.910734 - !!! Exception during processing !!! Expected all tensors to be on the same device, but got index is on cpu, different from other tensors on cuda:0 (when checking argument in method wrapper_CUDA__index_select)
2026-02-19T18:15:58.913809 - Traceback (most recent call last):
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\execution.py", line 530, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\execution.py", line 334, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\comfyui-lora-manager\py\metadata_collector\metadata_hook.py", line 168, in async_map_node_over_list_with_metadata
    results = await original_map_node_over_list(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
    )
    ^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\execution.py", line 308, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\execution.py", line 296, in process_inputs
    result = f(**inputs)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\efficiency_nodes.py", line 250, in efficientloaderSDXL
    return super().efficientloader(base_ckpt_name, vae_name, clip_skip, lora_name, lora_model_strength, lora_clip_strength,
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                    positive, negative, token_normalization, weight_interpretation, empty_latent_width, empty_latent_height,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                    batch_size, lora_stack=lora_stack, cnet_stack=cnet_stack, refiner_name=refiner_ckpt_name,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                    ascore=(positive_ascore, negative_ascore), prompt=prompt, my_unique_id=my_unique_id, loader_type="sdxl")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\efficiency_nodes.py", line 186, in efficientloader
    encode_prompts(positive, negative, token_normalization, weight_interpretation, clip, clip_skip,
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   refiner_clip, refiner_clip_skip, ascore, loader_type == "sdxl",
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                   empty_latent_width, empty_latent_height)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\efficiency_nodes.py", line 81, in encode_prompts
    positive_encoded = bnk_adv_encode.AdvancedCLIPTextEncode().encode(clip, positive_prompt, token_normalization, weight_interpretation)[0]
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\py\bnk_adv_encode.py", line 312, in encode
    embeddings_final, pooled = advanced_encode(clip, text, token_normalization, weight_interpretation, w_max=1.0,
                               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                               apply_to_pooled=affect_pooled == 'enable')
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\py\bnk_adv_encode.py", line 246, in advanced_encode
    embs_l, _ = advanced_encode_from_tokens(tokenized['l'],
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
                                         token_normalization,
                                         ^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
                                         w_max=w_max,
                                         ^^^^^^^^^^^^
                                         return_pooled=False)
                                         ^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\py\bnk_adv_encode.py", line 187, in advanced_encode_from_tokens
    base_emb, pooled_base = encode_func(unweighted_tokens)
                            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\py\bnk_adv_encode.py", line 249, in <lambda>
    lambda x: encode_token_weights(clip, x, encode_token_weights_l),
              ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\py\bnk_adv_encode.py", line 229, in encode_token_weights
    return encode_func(model.cond_stage_model, token_weight_pairs)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\custom_nodes\efficiency-nodes-comfyui\py\bnk_adv_encode.py", line 221, in encode_token_weights_l
    l_out, _ = model.clip_l.encode_token_weights(token_weight_pairs)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\comfy\sd1_clip.py", line 45, in encode_token_weights
    o = self.encode(to_encode)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\comfy\sd1_clip.py", line 299, in encode
    return self(tokens)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\comfy\sd1_clip.py", line 259, in forward
    embeds, attention_mask, num_tokens, embeds_info = self.process_tokens(tokens, device)
                                                      ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\comfy\sd1_clip.py", line 206, in process_tokens
    tokens_embed = self.transformer.get_input_embeddings()(tokens_embed, out_dtype=torch.float32)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\modules\module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\comfy\ops.py", line 549, in forward
    return self.forward_comfy_cast_weights(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\ComfyUI\comfy\ops.py", line 541, in forward_comfy_cast_weights
    x = torch.nn.functional.embedding(input, weight, self.padding_idx, self.max_norm, self.norm_type, self.scale_grad_by_freq, self.sparse).to(dtype=output_dtype)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\ComfyUI_files\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\nn\functional.py", line 2567, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected all tensors to be on the same device, but got index is on cpu, different from other tensors on cuda:0 (when checking argument in method wrapper_CUDA__index_select)

```