### PR TITLE
Fix deprecated legacy API imports with modern API shims

### DIFF
--- a/js/node_options/common/modelInfoDialog.js
+++ b/js/node_options/common/modelInfoDialog.js
@@ -1,4 +1,11 @@
-import { $el, ComfyDialog } from "../../../../scripts/ui.js";
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el, ComfyDialog;
+if (window?.comfyAPI?.ui) {
+    ({ $el, ComfyDialog } = window.comfyAPI.ui);
+} else {
+    ({ $el, ComfyDialog } = await import("../../../../scripts/ui.js"));
+}
+
 import { api } from "../../../../scripts/api.js";
 import { addStylesheet } from "./utils.js";
 

--- a/js/node_options/common/modelInfoDialog.js
+++ b/js/node_options/common/modelInfoDialog.js
@@ -1,3 +1,5 @@
+import { api } from "../../../../scripts/api.js";
+import { addStylesheet } from "./utils.js";
 // === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
 let $el, ComfyDialog;
 if (window?.comfyAPI?.ui) {
@@ -5,9 +7,6 @@ if (window?.comfyAPI?.ui) {
 } else {
     ({ $el, ComfyDialog } = await import("../../../../scripts/ui.js"));
 }
-
-import { api } from "../../../../scripts/api.js";
-import { addStylesheet } from "./utils.js";
 
 addStylesheet(import.meta.url);
 

--- a/js/node_options/common/utils.js
+++ b/js/node_options/common/utils.js
@@ -1,5 +1,11 @@
 import { app } from '../../../../scripts/app.js'
-import { $el } from "../../../../scripts/ui.js";
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el;
+if (window?.comfyAPI?.ui) {
+    ({ $el } = window.comfyAPI.ui);
+} else {
+    ({ $el } = await import("../../../../scripts/ui.js"));
+}
 
 export function addStylesheet(url) {
 	if (url.endsWith(".js")) {

--- a/js/node_options/modelInfo.js
+++ b/js/node_options/modelInfo.js
@@ -1,4 +1,6 @@
 import { app } from "../../../scripts/app.js";
+import { ModelInfoDialog } from "./common/modelInfoDialog.js";
+import { addMenuHandler } from "./common/utils.js";
 // === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
 let $el;
 if (window?.comfyAPI?.ui) {
@@ -6,9 +8,6 @@ if (window?.comfyAPI?.ui) {
 } else {
     ({ $el } = await import("../../../scripts/ui.js"));
 }
-
-import { ModelInfoDialog } from "./common/modelInfoDialog.js";
-import { addMenuHandler } from "./common/utils.js";
 
 const MAX_TAGS = 500;
 

--- a/js/node_options/modelInfo.js
+++ b/js/node_options/modelInfo.js
@@ -1,5 +1,12 @@
 import { app } from "../../../scripts/app.js";
-import { $el } from "../../../scripts/ui.js";
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el;
+if (window?.comfyAPI?.ui) {
+    ({ $el } = window.comfyAPI.ui);
+} else {
+    ({ $el } = await import("../../../scripts/ui.js"));
+}
+
 import { ModelInfoDialog } from "./common/modelInfoDialog.js";
 import { addMenuHandler } from "./common/utils.js";
 


### PR DESCRIPTION
ComfyUI has deprecated direct imports of /scripts/ui.js and now logs 
DEPRECATION WARNING in the console when these paths are imported 
directly by extensions.

This replaces the static imports in 3 files with shims that check for 
the new window.comfyAPI.ui API first, falling back to the legacy path 
for backward compatibility:

- node_options/modelInfo.js
- node_options/common/modelInfoDialog.js
- node_options/common/utils.js