### PR TITLE
Add XY Input: Diffusion Model node with manual and batch model-selection modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please check out our WIKI for any use cases and new developments including workf
         <summary><b>XY Plot</b></summary>
     <ul>
         <li>Node that allows users to specify parameters for the Efficiency KSamplers to plot on a grid.</li>
-        <li>The <b>XY Input: Diffusion Model</b> input batches over diffusion model (UNet) files for workflows where the model is loaded separately from CLIP/VAE (e.g. Wan, HunyuanVideo, Flux). Point it at a folder of models; CLIP and VAE stay wired to the KSampler as usual (no Efficient Loader / dependencies input needed).</li>
+        <li>The <b>XY Input: Diffusion Model</b> input plots diffusion model (UNet) files for workflows where the model loads separately from CLIP/VAE (e.g. Wan, HunyuanVideo, Flux). Pick models from the dropdowns, or point it at a folder to batch over all of them; CLIP and VAE stay wired to the KSampler as usual (no Efficient Loader / dependencies input needed).</li>
     </ul>
     <p align="center">
       <img src="https://github.com/LucianoCirino/efficiency-nodes-media/blob/main/images/nodes/XY%20Plot%20-%20Node%20Example.png" width="1080">
@@ -311,7 +311,7 @@ Please check out our WIKI for any use cases and new developments including workf
         <summary><b>XY Plot</b></summary>
     <ul>
         <li>Node that allows users to specify parameters for the Efficiency KSamplers to plot on a grid.</li>
-        <li>The <b>XY Input: Diffusion Model</b> input batches over diffusion model (UNet) files for workflows where the model is loaded separately from CLIP/VAE (e.g. Wan, HunyuanVideo, Flux). Point it at a folder of models; CLIP and VAE stay wired to the KSampler as usual (no Efficient Loader / dependencies input needed).</li>
+        <li>The <b>XY Input: Diffusion Model</b> input plots diffusion model (UNet) files for workflows where the model loads separately from CLIP/VAE (e.g. Wan, HunyuanVideo, Flux). Pick models from the dropdowns, or point it at a folder to batch over all of them; CLIP and VAE stay wired to the KSampler as usual (no Efficient Loader / dependencies input needed).</li>
     </ul>
     <p align="center">
       <img src="https://github.com/LucianoCirino/efficiency-nodes-media/blob/main/images/nodes/XY%20Plot%20-%20Node%20Example.png" width="1080">

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Please check out our WIKI for any use cases and new developments including workf
         <summary><b>XY Plot</b></summary>
     <ul>
         <li>Node that allows users to specify parameters for the Efficiency KSamplers to plot on a grid.</li>
+        <li>The <b>XY Input: Diffusion Model</b> input batches over diffusion model (UNet) files for workflows where the model is loaded separately from CLIP/VAE (e.g. Wan, HunyuanVideo, Flux). Point it at a folder of models; CLIP and VAE stay wired to the KSampler as usual (no Efficient Loader / dependencies input needed).</li>
     </ul>
     <p align="center">
       <img src="https://github.com/LucianoCirino/efficiency-nodes-media/blob/main/images/nodes/XY%20Plot%20-%20Node%20Example.png" width="1080">
@@ -310,6 +311,7 @@ Please check out our WIKI for any use cases and new developments including workf
         <summary><b>XY Plot</b></summary>
     <ul>
         <li>Node that allows users to specify parameters for the Efficiency KSamplers to plot on a grid.</li>
+        <li>The <b>XY Input: Diffusion Model</b> input batches over diffusion model (UNet) files for workflows where the model is loaded separately from CLIP/VAE (e.g. Wan, HunyuanVideo, Flux). Point it at a folder of models; CLIP and VAE stay wired to the KSampler as usual (no Efficient Loader / dependencies input needed).</li>
     </ul>
     <p align="center">
       <img src="https://github.com/LucianoCirino/efficiency-nodes-media/blob/main/images/nodes/XY%20Plot%20-%20Node%20Example.png" width="1080">

--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -141,7 +141,7 @@ class TSC_EfficientLoader:
         latent = torch.zeros([batch_size, 4, empty_latent_height // 8, empty_latent_width // 8]).cpu()
 
         # Retrieve cache numbers
-        vae_cache, ckpt_cache, lora_cache, refn_cache = get_cache_numbers("Efficient Loader")
+        vae_cache, ckpt_cache, lora_cache, refn_cache, _unet_cache = get_cache_numbers("Efficient Loader")
 
         if lora_name != "None" or lora_stack:
             # Initialize an empty list to store LoRa parameters.
@@ -875,6 +875,9 @@ class TSC_KSampler:
                 elif type_ == "Scheduler" and isinstance(value, tuple):
                     return value[0]  # Return only the first entry of the tuple
 
+                elif type_ == "DiffusionModel" and isinstance(value, list):
+                    return [os.path.basename(v[0]) for v in value]
+
                 elif type_ == "VAE" and isinstance(value, list):
                     # For each string in the list, extract the filename from the path
                     return [os.path.basename(v) for v in value]
@@ -943,12 +946,12 @@ class TSC_KSampler:
 
             # If not caching models, set to 1.
             if cache_models == "False":
-                vae_cache = ckpt_cache = lora_cache = refn_cache = 1
+                vae_cache = ckpt_cache = lora_cache = refn_cache = unet_cache = 1
             else:
                 # Retrieve cache numbers
-                vae_cache, ckpt_cache, lora_cache, refn_cache = get_cache_numbers("XY Plot")
+                vae_cache, ckpt_cache, lora_cache, refn_cache, unet_cache = get_cache_numbers("XY Plot")
             # Pack cache numbers in a tuple
-            cache = (vae_cache, ckpt_cache, lora_cache, refn_cache)
+            cache = (vae_cache, ckpt_cache, lora_cache, refn_cache, unet_cache)
 
             # Add seed to every entry in the list
             X_value = [v + seed for v in X_value] if "Seeds++ Batch" == X_type else X_value
@@ -987,6 +990,7 @@ class TSC_KSampler:
                 "Refiner",
                 "LoRA",
                 "LoRA Stacks",
+                "DiffusionModel",
                 "VAE",
             ]
             conditioners = {
@@ -1027,7 +1031,7 @@ class TSC_KSampler:
             # Note: Special LoRA types will not trigger cache: "LoRA Batch", "LoRA Wt", "LoRA MStr", "LoRA CStr"
 
             # Map the type names to the dictionaries
-            dict_map = {"VAE": [], "Checkpoint": [], "LoRA": [], "Refiner": []}
+            dict_map = {"VAE": [], "Checkpoint": [], "LoRA": [], "Refiner": [], "DiffusionModel": []}
 
             # Create a list of tuples with types and values
             type_value_pairs = [(X_type, X_value.copy()), (Y_type, Y_value.copy())]
@@ -1063,6 +1067,12 @@ class TSC_KSampler:
             else:
                 refn_dict = []
 
+            # Construct unet_dict
+            if dict_map.get("DiffusionModel", []):
+                unet_dict = [t[0] for t in dict_map["DiffusionModel"]]
+            else:
+                unet_dict = []
+
             # If both ckpt_dict and lora_dict are not empty, manipulate lora_dict as described
             if ckpt_dict and lora_dict:
                 lora_dict = [(lora_stack, ckpt) for ckpt in ckpt_dict for lora_stack in lora_dict]
@@ -1085,7 +1095,7 @@ class TSC_KSampler:
             ###print(f"vae_dict={vae_dict}\nckpt_dict={ckpt_dict}\nlora_dict={lora_dict}\nrefn_dict={refn_dict}")
 
             # Clean values that won't be reused
-            clear_cache_by_exception(xyplot_id, vae_dict=vae_dict, ckpt_dict=ckpt_dict, lora_dict=lora_dict, refn_dict=refn_dict)
+            clear_cache_by_exception(xyplot_id, vae_dict=vae_dict, ckpt_dict=ckpt_dict, lora_dict=lora_dict, refn_dict=refn_dict, unet_dict=unet_dict)
 
             ### Print loaded_objects for debugging
             ###print_loaded_objects_entries()
@@ -1245,6 +1255,11 @@ class TSC_KSampler:
                     end_at_step = int(var * steps)
                     text = f"Refiner: {'On' if var < 1 else 'Off'}"
 
+                elif var_type == "DiffusionModel":
+                    ckpt_name = var  # var = (unet_name, weight_dtype)
+                    unet_filename = os.path.splitext(os.path.basename(var[0]))[0]
+                    text = f"{unet_filename}"
+
                 elif var_type == "Clip Skip":
                     clip_skip = (var, clip_skip[1])
                     text = f"ClipSkip ({clip_skip[0]})"
@@ -1361,7 +1376,8 @@ class TSC_KSampler:
 
                 # If var_type VAE , truncate entries in the var_label list when it's full
                 if len(var_label) == num_label and (var_type == "VAE" or var_type == "Checkpoint"
-                                                    or var_type == "Refiner" or "LoRA" in var_type):
+                                                    or var_type == "Refiner" or "LoRA" in var_type
+                                                    or var_type == "DiffusionModel"):
                     var_label = truncate_texts(var_label, num_label, max_label_len)
 
                 # Return the modified variables
@@ -1408,6 +1424,11 @@ class TSC_KSampler:
                     # Don't cache Checkpoints or LoRAs
                     model, clip = load_lora(lora_stack, ckpt_name, xyplot_id, cache=0)
                     encode = True
+
+                # Load Diffusion Model (UNet) if required — CLIP stays external, no re-encode needed
+                if (X_type == "DiffusionModel" and index == 0) or Y_type == "DiffusionModel":
+                    unet_name, weight_dtype = ckpt_name
+                    model = load_diffusion_model(unet_name, weight_dtype, xyplot_id, cache=cache[4])
 
                 if (X_type == "Refiner" and index == 0) or Y_type == "Refiner":
                     refiner_model, refiner_clip, _ = \
@@ -1610,7 +1631,7 @@ class TSC_KSampler:
 
             # Clean up cache
             if cache_models == "False":
-                clear_cache_by_exception(xyplot_id, vae_dict=[], ckpt_dict=[], lora_dict=[], refn_dict=[])
+                clear_cache_by_exception(xyplot_id, vae_dict=[], ckpt_dict=[], lora_dict=[], refn_dict=[], unet_dict=[])
             else:
                 # Avoid caching models accross both X and Y
                 if X_type == "Checkpoint":
@@ -1619,6 +1640,8 @@ class TSC_KSampler:
                     clear_cache_by_exception(xyplot_id, ckpt_dict=[], lora_dict=[])
                 elif X_type in ("LoRA", "LoRA Stacks"):
                     clear_cache_by_exception(xyplot_id, ckpt_dict=[], refn_dict=[])
+                elif X_type == "DiffusionModel":
+                    pass  # unet cache is independent of ckpt/lora/refn
 
             # __________________________________________________________________________________________________________
             # Function for printing all plot variables (WARNING: This function is an absolute mess)
@@ -1799,6 +1822,15 @@ class TSC_KSampler:
                     else:
                         return ""
 
+                # Diffusion Model (UNet) — build its own printable name list and prevent the
+                # checkpoint logic below from choking on the (unet_name, weight_dtype) tuple.
+                diffusion_model_name = None
+                if X_type == "DiffusionModel" or Y_type == "DiffusionModel":
+                    dm_value = X_value if X_type == "DiffusionModel" else Y_value
+                    diffusion_model_name = "\n      ".join(
+                        [os.path.splitext(os.path.basename(str(v[0])))[0] for v in dm_value])
+                    ckpt_name = None
+
                 # VAE, Checkpoint, Clip Skip, LoRA
                 ckpt_name, clip_skip, vae_name = get_checkpoint_name(X_type, Y_type, X_value, Y_value, ckpt_name, clip_skip, "ckpt", vae_name)
                 lora_name, lora_wt, lora_model_str, lora_clip_str = get_lora_name(X_type, Y_type, X_value, Y_value, lora_stack)
@@ -1873,6 +1905,8 @@ class TSC_KSampler:
                 print(f"img_dims: {i_height} x {i_width}")
                 print(f"plot_dim: {num_cols} x {num_rows}")
                 print(f"ckpt: {ckpt_name if ckpt_name is not None else ''}")
+                if diffusion_model_name:
+                    print(f"diffusion_model: {diffusion_model_name}")
                 if clip_skip:
                     print(f"clip_skip: {clip_skip}")
                 if sampler_type == "sdxl":
@@ -2909,6 +2943,50 @@ class TSC_XYplot_Checkpoint:
                 return (None,)
 
         return ((xy_type, xy_value),) if xy_value else (None,)
+
+#=======================================================================================================================
+# TSC XY Plot: Diffusion Model (UNet — for Wan/HunyuanVideo/etc. workflows with separate CLIP)
+class TSC_XYplot_DiffusionModel:
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+            "batch_path":     ("STRING", {"default": xy_batch_default_path, "multiline": False}),
+            "subdirectories": ("BOOLEAN", {"default": False}),
+            "batch_sort":     (["ascending", "descending"],),
+            "batch_max":      ("INT", {"default": -1, "min": -1, "max": XYPLOT_LIM, "step": 1}),
+            "weight_dtype":   (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],),
+        }}
+
+    RETURN_TYPES = ("XY",)
+    RETURN_NAMES = ("X or Y",)
+    FUNCTION = "xy_value"
+    CATEGORY = "Efficiency Nodes/XY Inputs"
+
+    def xy_value(self, batch_path, subdirectories, batch_sort, batch_max, weight_dtype):
+        if batch_max == 0:
+            return (None,)
+
+        try:
+            model_files = get_batch_files(batch_path, CKPT_EXTENSIONS, include_subdirs=subdirectories)
+        except Exception as e:
+            print(f"{error('XY Plot Error:')} {e}")
+            return (None,)
+
+        if not model_files:
+            print(f"{error('XY Plot Error:')} No diffusion model files found in: {batch_path}")
+            return (None,)
+
+        if batch_sort == "ascending":
+            model_files.sort()
+        else:
+            model_files.sort(reverse=True)
+
+        if batch_max != -1:
+            model_files = model_files[:batch_max]
+
+        xy_value = [(m, weight_dtype) for m in model_files]
+        return (("DiffusionModel", xy_value),)
 
 #=======================================================================================================================
 # TSC XY Plot: LoRA Batch (DISABLED)
@@ -4284,6 +4362,7 @@ NODE_CLASS_MAPPINGS = {
     "XY Input: Aesthetic Score": TSC_XYplot_AScore,
     "XY Input: Refiner On/Off": TSC_XYplot_Refiner_OnOff,
     "XY Input: Checkpoint": TSC_XYplot_Checkpoint,
+    "XY Input: Diffusion Model": TSC_XYplot_DiffusionModel,
     "XY Input: Clip Skip": TSC_XYplot_ClipSkip,
     "XY Input: LoRA": TSC_XYplot_LoRA,
     "XY Input: LoRA Plot": TSC_XYplot_LoRA_Plot,

--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -2948,45 +2948,63 @@ class TSC_XYplot_Checkpoint:
 # TSC XY Plot: Diffusion Model (UNet — for Wan/HunyuanVideo/etc. workflows with separate CLIP)
 class TSC_XYplot_DiffusionModel:
 
+    modes = ["Model Names", "Diffusion Model Batch"]
+
     @classmethod
     def INPUT_TYPES(cls):
-        return {"required": {
-            "batch_path":     ("STRING", {"default": xy_batch_default_path, "multiline": False}),
-            "subdirectories": ("BOOLEAN", {"default": False}),
-            "batch_sort":     (["ascending", "descending"],),
-            "batch_max":      ("INT", {"default": -1, "min": -1, "max": XYPLOT_LIM, "step": 1}),
-            "weight_dtype":   (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],),
-        }}
+        models = ["None"] + folder_paths.get_filename_list("diffusion_models")
+
+        inputs = {
+            "required": {
+                "input_mode":     (cls.modes,),
+                "batch_path":     ("STRING", {"default": xy_batch_default_path, "multiline": False}),
+                "subdirectories": ("BOOLEAN", {"default": False}),
+                "batch_sort":     (["ascending", "descending"],),
+                "batch_max":      ("INT", {"default": -1, "min": -1, "max": XYPLOT_LIM, "step": 1}),
+                "model_count":    ("INT", {"default": XYPLOT_DEF, "min": 0, "max": XYPLOT_LIM, "step": 1}),
+                "weight_dtype":   (["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"],),
+            }
+        }
+
+        for i in range(1, XYPLOT_LIM+1):
+            inputs["required"][f"model_name_{i}"] = (models,)
+
+        return inputs
 
     RETURN_TYPES = ("XY",)
     RETURN_NAMES = ("X or Y",)
     FUNCTION = "xy_value"
     CATEGORY = "Efficiency Nodes/XY Inputs"
 
-    def xy_value(self, batch_path, subdirectories, batch_sort, batch_max, weight_dtype):
-        if batch_max == 0:
-            return (None,)
-
-        try:
-            model_files = get_batch_files(batch_path, CKPT_EXTENSIONS, include_subdirs=subdirectories)
-        except Exception as e:
-            print(f"{error('XY Plot Error:')} {e}")
-            return (None,)
-
-        if not model_files:
-            print(f"{error('XY Plot Error:')} No diffusion model files found in: {batch_path}")
-            return (None,)
-
-        if batch_sort == "ascending":
-            model_files.sort()
+    def xy_value(self, input_mode, batch_path, subdirectories, batch_sort, batch_max, model_count, weight_dtype, **kwargs):
+        if "Batch" not in input_mode:
+            names = [kwargs.get(f"model_name_{i}") for i in range(1, model_count + 1)]
+            xy_value = [(name, weight_dtype) for name in names if name != "None"]
         else:
-            model_files.sort(reverse=True)
+            if batch_max == 0:
+                return (None,)
 
-        if batch_max != -1:
-            model_files = model_files[:batch_max]
+            try:
+                model_files = get_batch_files(batch_path, CKPT_EXTENSIONS, include_subdirs=subdirectories)
+            except Exception as e:
+                print(f"{error('XY Plot Error:')} {e}")
+                return (None,)
 
-        xy_value = [(m, weight_dtype) for m in model_files]
-        return (("DiffusionModel", xy_value),)
+            if not model_files:
+                print(f"{error('XY Plot Error:')} No diffusion model files found in: {batch_path}")
+                return (None,)
+
+            if batch_sort == "ascending":
+                model_files.sort()
+            else:
+                model_files.sort(reverse=True)
+
+            if batch_max != -1:
+                model_files = model_files[:batch_max]
+
+            xy_value = [(m, weight_dtype) for m in model_files]
+
+        return (("DiffusionModel", xy_value),) if xy_value else (None,)
 
 #=======================================================================================================================
 # TSC XY Plot: LoRA Batch (DISABLED)

--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -72,6 +72,7 @@ function handleInputModeWidgetsVisibility(node, inputModeValue) {
     const vaeNameWidgets = [...generateWidgetNames("vae_name", 50)];
     const loraNameWidgets = [...generateWidgetNames("lora_name", 50)];
     const loraWtWidgets = [...generateWidgetNames("lora_wt", 50)];
+    const modelNameWidgets = [...generateWidgetNames("model_name", 50)];
     const modelStrWidgets = [...generateWidgetNames("model_str", 50)];
     const clipStrWidgets = [...generateWidgetNames("clip_str", 50)];
     const xWidgets = ["X_batch_count", "X_first_value", "X_last_value"]
@@ -91,6 +92,10 @@ function handleInputModeWidgetsVisibility(node, inputModeValue) {
         "XY Input: VAE": {
             "VAE Names": [...batchWidgets],
             "VAE Batch": [...vaeNameWidgets, "vae_count"]
+        },
+        "XY Input: Diffusion Model": {
+            "Model Names": [...batchWidgets],
+            "Diffusion Model Batch": [...modelNameWidgets, "model_count"]
         },
         "XY Input: Checkpoint": {
             "Ckpt Names": [...clipSkipWidgets, ...vaeNameWidgets, ...batchWidgets],
@@ -279,6 +284,10 @@ const nodeWidgetHandlers = {
     "XY Input: VAE": {
         'input_mode': handleXYInputVAEInputMode,
         'vae_count': handleXYInputVAEVaeCount
+    },
+    "XY Input: Diffusion Model": {
+        'input_mode': handleXYInputDiffusionModelInputMode,
+        'model_count': handleXYInputDiffusionModelModelCount
     },
     "XY Input: Prompt S/R": {
         'replace_count': handleXYInputPromptSRReplaceCount
@@ -550,6 +559,22 @@ function handleXYInputVAEInputMode(node, widget) {
 function handleXYInputVAEVaeCount(node, widget) {
     if (findWidgetByName(node, "input_mode").value === "VAE Names") {
         handleWidgetVisibility(node, widget.value, "vae_name_", 50);
+    }
+}
+
+// XY Input: Diffusion Model Handlers
+function handleXYInputDiffusionModelInputMode(node, widget) {
+    handleInputModeWidgetsVisibility(node, widget.value);
+    if (widget.value === "Model Names") {
+        handleWidgetVisibility(node, findWidgetByName(node, "model_count").value, "model_name_", 50);
+    } else {
+        handleWidgetVisibility(node, 0, "model_name_", 50);
+    }
+}
+
+function handleXYInputDiffusionModelModelCount(node, widget) {
+    if (findWidgetByName(node, "input_mode").value === "Model Names") {
+        handleWidgetVisibility(node, widget.value, "model_name_", 50);
     }
 }
 

--- a/node_settings.json
+++ b/node_settings.json
@@ -12,7 +12,8 @@
             "vae": 5,
             "ckpt": 5,
             "lora": 5,
-            "refn": 1
+            "refn": 1,
+            "unet": 3
         }
     }
 }

--- a/tsc_utils.py
+++ b/tsc_utils.py
@@ -33,7 +33,8 @@ loaded_objects = {
     "ckpt": [], # (ckpt_name, ckpt_model, clip, bvae, [id])
     "refn": [], # (ckpt_name, ckpt_model, clip, bvae, [id])
     "vae": [],  # (vae_name, vae, [id])
-    "lora": []  # ([(lora_name, strength_model, strength_clip)], ckpt_name, lora_model, clip_lora, [id])
+    "lora": [], # ([(lora_name, strength_model, strength_clip)], ckpt_name, lora_model, clip_lora, [id])
+    "unet": [], # (unet_name, weight_dtype, model, [id])
 }
 
 # Cache for Efficient Ksamplers
@@ -161,7 +162,7 @@ def print_loaded_objects_entries(id=None, prompt=None, show_id=False):
     else:
         print(f"\033[36mModels Cache: \nnode_id:{int(id)}\033[0m")
     entries_found = False
-    for key in ["ckpt", "refn", "vae", "lora"]:
+    for key in ["ckpt", "refn", "vae", "lora", "unet"]:
         entries_with_id = loaded_objects[key] if id is None else [entry for entry in loaded_objects[key] if id in entry[-1]]
         if not entries_with_id:  # If no entries with the chosen ID, print None and skip this key
             continue
@@ -266,6 +267,55 @@ def load_checkpoint(ckpt_name, id, output_vae=True, cache=None, cache_overwrite=
                 loaded_objects[ckpt_type].append((ckpt_name, model, clip, vae, [id]))
 
     return model, clip, vae
+
+def load_diffusion_model(unet_name, weight_dtype, id, cache=None, cache_overwrite=True):
+    global loaded_objects
+
+    unet_name = unet_name.copy() if isinstance(unet_name, (list, dict, set)) else unet_name
+
+    for entry in loaded_objects["unet"]:
+        if entry[0] == unet_name and entry[1] == weight_dtype:
+            _, _, model, ids = entry
+            cache_full = cache and len([e for e in loaded_objects["unet"] if id in e[-1]]) >= cache
+            if cache_full:
+                clear_cache(id, cache, "unet")
+            elif id not in ids:
+                ids.append(id)
+            return model
+
+    model_options = {}
+    if weight_dtype == "fp8_e4m3fn":
+        model_options["dtype"] = torch.float8_e4m3fn
+    elif weight_dtype == "fp8_e4m3fn_fast":
+        model_options["dtype"] = torch.float8_e4m3fn
+        model_options["fp8_optimizations"] = True
+    elif weight_dtype == "fp8_e5m2":
+        model_options["dtype"] = torch.float8_e5m2
+
+    if os.path.isabs(unet_name):
+        unet_path = unet_name
+    else:
+        unet_path = folder_paths.get_full_path("diffusion_models", unet_name)
+
+    with suppress_output():
+        model = comfy.sd.load_diffusion_model(unet_path, model_options=model_options)
+
+    if cache:
+        cache_list = [e for e in loaded_objects["unet"] if id in e[-1]]
+        if len(cache_list) < cache:
+            loaded_objects["unet"].append((unet_name, weight_dtype, model, [id]))
+        else:
+            clear_cache(id, cache, "unet")
+            if cache_overwrite:
+                for e in loaded_objects["unet"]:
+                    if id in e[-1]:
+                        e[-1].remove(id)
+                        if not e[-1]:
+                            loaded_objects["unet"].remove(e)
+                        break
+                loaded_objects["unet"].append((unet_name, weight_dtype, model, [id]))
+
+    return model
 
 def get_bvae_by_ckpt_name(ckpt_name):
     for ckpt in loaded_objects["ckpt"]:
@@ -418,17 +468,18 @@ def clear_cache(id, cache, dict_name):
         id_associated_entries = [entry for entry in loaded_objects[dict_name] if id in entry[-1]]
 
 
-def clear_cache_by_exception(node_id, vae_dict=None, ckpt_dict=None, lora_dict=None, refn_dict=None):
+def clear_cache_by_exception(node_id, vae_dict=None, ckpt_dict=None, lora_dict=None, refn_dict=None, unet_dict=None):
     global loaded_objects
 
     dict_mapping = {
         "vae_dict": "vae",
         "ckpt_dict": "ckpt",
         "lora_dict": "lora",
-        "refn_dict": "refn"
+        "refn_dict": "refn",
+        "unet_dict": "unet",
     }
 
-    for arg_name, arg_val in {"vae_dict": vae_dict, "ckpt_dict": ckpt_dict, "lora_dict": lora_dict, "refn_dict": refn_dict}.items():
+    for arg_name, arg_val in {"vae_dict": vae_dict, "ckpt_dict": ckpt_dict, "lora_dict": lora_dict, "refn_dict": refn_dict, "unet_dict": unet_dict}.items():
         if arg_val is None:
             continue
 
@@ -468,7 +519,8 @@ def get_cache_numbers(node_name):
     ckpt_cache = int(model_cache_settings.get('ckpt', 1))
     lora_cache = int(model_cache_settings.get('lora', 1))
     refn_cache = int(model_cache_settings.get('ckpt', 1))
-    return vae_cache, ckpt_cache, lora_cache, refn_cache,
+    unet_cache = int(model_cache_settings.get('unet', 1))
+    return vae_cache, ckpt_cache, lora_cache, refn_cache, unet_cache
 
 def print_last_helds(id=None):
     print("\n" + "-" * 40)  # Print an empty line followed by a separator line


### PR DESCRIPTION
## Summary

Adds a new **XY Input: Diffusion Model** node for plotting over diffusion-model (UNet) files — for workflows where the model is loaded separately from CLIP/VAE (Wan, HunyuanVideo, Flux, Anima, etc.) instead of as a single checkpoint.

- **Two selection modes**, mirroring the existing XY Input: VAE node:
  - **Model Names** — pick models from dropdowns (`model_count` controls how many)
  - **Diffusion Model Batch** — scan a folder for model files
- CLIP and VAE stay wired directly to the KSampler — **no Efficient Loader / DEPENDENCIES input required**, and prompts aren't re-encoded since CLIP is unchanged.
- Loads via `comfy.sd.load_diffusion_model` with the same `weight_dtype` options as core's UNETLoader (default / fp8_e4m3fn / fp8_e4m3fn_fast / fp8_e5m2).

## Implementation

- New `TSC_XYplot_DiffusionModel` node; both modes emit the same `(unet_name, weight_dtype)` value shape, so the XY engine needed no special-casing beyond a `DiffusionModel` type handled in `define_variable` / `define_model` / `process_xy_for_print` / `print_plot_variables`.
- New `unet` model cache in `loaded_objects` with a `load_diffusion_model()` loader, wired through `clear_cache_by_exception`, `get_cache_numbers`, and `node_settings.json`.
- `js/widgethider.js` integration so the dropdown/batch widgets show/hide by mode (mirrors the VAE handlers).

## Test plan

- [x] Batch mode plots every model file in a folder
- [x] Model Names mode plots the selected dropdown entries (extra/None slots ignored)
- [x] CLIP + VAE wired directly to KSampler (Eff.); no dependencies input
- [x] Verified against current `main` (preserves the Image Overlay #365 fix)