### PR TITLE
Fix stray last widget on count-based XY Input nodes

### DIFF
--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -28,6 +28,10 @@ function toggleWidget(node, widget, show = false, suffix = "") {
     widget.type = show ? origProps[widget.name].origType : HIDDEN_TAG + suffix;
     widget.computeSize = show ? origProps[widget.name].origComputeSize : () => [0, -4];
 
+    // Modern ComfyUI frontends honor widget.hidden; the type/computeSize hack alone
+    // leaves the last hidden widget rendered (and drawn outside the node bounds).
+    widget.hidden = !show;
+
     // Recursively handle linked widgets if they exist
     widget.linkedWidgets?.forEach(w => toggleWidget(node, w, ":" + widget.name, show));
 

--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -30,7 +30,9 @@ function toggleWidget(node, widget, show = false, suffix = "") {
 
     // Modern ComfyUI frontends honor widget.hidden; the type/computeSize hack alone
     // leaves the last hidden widget rendered (and drawn outside the node bounds).
+    // the second line handles the state connection with detail panel on the right hand side (and keep all param lines in box).
     widget.hidden = !show;
+    if (widget.options) widget.options.hidden = !show;
 
     // Recursively handle linked widgets if they exist
     widget.linkedWidgets?.forEach(w => toggleWidget(node, w, ":" + widget.name, show));


### PR DESCRIPTION
## Summary

`toggleWidget` in `js/widgethider.js` hides widgets by renaming their `type` to `"tschide"` and setting `computeSize` to `() => [0, -4]`. On recent ComfyUI frontends this no longer fully suppresses rendering — the **last** hidden widget still paints, frequently drawn at the bottom outside the node's frame. It shows up as a stray trailing slot (e.g. `vae_name_50`, `ckpt_name_50`) on the count-based XY Input nodes.

## Fix

Set `widget.hidden = !show` in `toggleWidget`, which the modern frontend honors. One line — and because every node that hides widgets routes through `toggleWidget`, it fixes them all: XY Input VAE / Checkpoint / LoRA / LoRA Stacks / Sampler-Scheduler / Prompt S/R, the LoRA Stacker, etc.

## Notes

- Verified on ComfyUI frontend 1.43.18: stray trailing slot is gone across the affected nodes; show/hide behavior is otherwise unchanged.
- Lightly overlaps #343 (which moves the resize out of `toggleWidget`) — same function, different lines; should merge cleanly either order.

## Test plan

- [x] Drop XY Input: VAE / Checkpoint / LoRA and vary the count — no stray slot, correct slots show/hide
- [x] Toggle input modes (names <-> batch) — widgets hide/show correctly

## Related

Part of the fix for #344 (efficiency-nodes UI trouble). This PR covers `toggleWidget` (XY Input / quantity-adjust nodes); #385 covers the same class of bug in `toggleWidget_2` (Efficient Loader text boxes). The two together resolve the widget-overlap issues reported in #344.