### PR TITLE
fix: set widget.hidden in toggleWidget_2 to prevent textarea overlap in modern frontend

### DIFF
--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -50,6 +50,7 @@ function toggleWidget_2(node, widget, show = false, suffix = "") {
 
     widget.type = show ? origProps[widget.name].origType : HIDDEN_TAG + suffix;
     widget.computeSize = show ? origProps[widget.name].origComputeSize : () => [0, -4];
+    widget.hidden = !show;
 
     if (initialized){
         const adjustment = show ? WIDGET_HEIGHT : -WIDGET_HEIGHT;

--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -51,6 +51,7 @@ function toggleWidget_2(node, widget, show = false, suffix = "") {
     widget.type = show ? origProps[widget.name].origType : HIDDEN_TAG + suffix;
     widget.computeSize = show ? origProps[widget.name].origComputeSize : () => [0, -4];
     widget.hidden = !show;
+    if (widget.options) widget.options.hidden = !show;
 
     if (initialized){
         const adjustment = show ? WIDGET_HEIGHT : -WIDGET_HEIGHT;


### PR DESCRIPTION
## Problem

In ComfyUI frontend >= v1.43.18, multiline STRING widgets (CLIP_POSITIVE / CLIP_NEGATIVE in the Efficient Loader) are rendered as DOM elements whose Y-position is calculated by accumulating the heights of all preceding widgets. The frontend uses `widget.hidden` to skip excluded widgets in this accumulation.

`toggleWidget_2` (used for the Efficient Loader) was hiding `lora_model_strength` and `lora_clip_strength` by setting `widget.type` and `widget.computeSize` only — without setting `widget.hidden`. Those widgets still contributed to the Y-offset accumulation, pushing the CLIP text boxes down into the fields below them (`token_normalization`, `weight_interpretation`, etc.).

## Fix

One line added to `toggleWidget_2`, mirroring the pattern already present in `toggleWidget`:

```js
widget.hidden = !show;
```

## Testing

Open an Efficient Loader node with `lora_name = None`. CLIP_POSITIVE and CLIP_NEGATIVE text boxes sit in their correct positions and no longer overlap the fields below them.

## Related

Part of the fix for #344 (efficiency-nodes UI trouble). This PR covers `toggleWidget_2` (Efficient Loader text boxes); #384 covers the same class of bug in `toggleWidget` (XY Input / quantity-adjust nodes). The two together resolve the widget-overlap issues reported in #344.