### PR TITLE
Fix swapped show/suffix args in toggleWidget linkedWidgets recursion

### DIFF
--- a/js/widgethider.js
+++ b/js/widgethider.js
@@ -28,8 +28,11 @@ function toggleWidget(node, widget, show = false, suffix = "") {
     widget.type = show ? origProps[widget.name].origType : HIDDEN_TAG + suffix;
     widget.computeSize = show ? origProps[widget.name].origComputeSize : () => [0, -4];
 
-    // Recursively handle linked widgets if they exist
-    widget.linkedWidgets?.forEach(w => toggleWidget(node, w, ":" + widget.name, show));
+    // Recursively handle linked widgets if they exist.
+    // Args are (node, widget, show, suffix) -- passing them swapped made `show` a
+    // non-empty string (always truthy), so linked widgets could never be hidden and
+    // the suffix became a boolean ("tschidefalse" instead of "tschide:<name>").
+    widget.linkedWidgets?.forEach(w => toggleWidget(node, w, show, ":" + widget.name));
 
     // Calculate the new height for the node based on its computeSize method
     const newHeight = node.computeSize()[1];


### PR DESCRIPTION
### Problem

`toggleWidget`'s signature is `(node, widget, show, suffix)`, but the `linkedWidgets` recursion passes the last two arguments in the wrong order:

```js
widget.linkedWidgets?.forEach(w => toggleWidget(node, w, ":" + widget.name, show));
```

So `show` receives `":" + widget.name` — a non-empty string, always truthy — and `suffix` receives the boolean. Two consequences:

1. **Linked widgets can never be hidden.** `show` is permanently truthy, so a linked child is restored to visible on every call regardless of its parent's state.
2. **The suffix becomes a boolean.** A hidden child's type would be `"tschidefalse"` instead of `"tschide:<parent name>"`, which also breaks `toggleWidget_2`'s `isCurrentlyVisible` comparison against `HIDDEN_TAG + suffix`.

### This is reachable today

Seed widgets carry a linked `control_after_generate` widget, and `widgethider.js` toggles `seed` on **Noise Control Script**, **HighRes-Fix Script** and **Tiled Upscaler Script**.

Turning off `add_seed_noise` on Noise Control Script hides `seed` and `weight` but leaves `control_after_generate` stranded on the node.

Confirmed on ComfyUI frontend v1.45.21:

```js
const n = app.graph.nodes.find(n => n.comfyClass === "Noise Control Script");
n.widgets.find(w => w.name === "seed").linkedWidgets.map(w => w.name)
// -> ['control_after_generate']
```

### Fix

Pass the arguments in the declared order.

### Testing

On Noise Control Script, toggling `add_seed_noise` off now hides `seed`, `weight` and `control_after_generate` together, and toggling it back on restores all three. Regression-checked HighRes-Fix Script (`upscale_type`, `use_same_seed`, `use_controlnet`) and Tiled Upscaler Script (`use_controlnet`), which use the same seed-toggle path.

### Note

This is independent of #384 and #385 and branches from `main`, so it can be merged in any order. It is worth noting that the visible symptom is more pronounced once those land: they make `toggleWidget` propagate `widget.hidden`, so a hidden parent leaves a visibly orphaned child rather than a merely mis-typed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)