### PR TITLE
Fix AttributeError: 'GITSScheduler' object has no attribute 'get_sigmas'

### DIFF
--- a/efficiency_nodes.py
+++ b/efficiency_nodes.py
@@ -485,9 +485,9 @@ class TSC_KSampler:
             # monkey patch the sample function
             def calculate_sigmas(model_sampling, scheduler_name: str, steps):
                 if scheduler_name.startswith("AYS"):
-                    return AlignYourStepsScheduler().get_sigmas(scheduler_name.split(" ")[1], steps, denoise=1.0)[0]
+                    return AlignYourStepsScheduler().execute(scheduler_name.split(" ")[1], steps, denoise=1.0)[0]
                 elif scheduler_name == "GITS":
-                    return GITSScheduler().get_sigmas(1.20, steps, denoise=1.0)[0]
+                    return GITSScheduler().execute(1.20, steps, denoise=1.0)[0]
                 return original_calculation(model_sampling, scheduler_name, steps)
 
             comfy.samplers.KSampler.SCHEDULERS = SCHEDULERS


### PR DESCRIPTION
### Problem

Selecting the **GITS** scheduler on **KSampler (Efficient)** — directly, or via an XY Plot scheduler sweep that includes `GITS` — raises:

```
AttributeError: 'GITSScheduler' object has no attribute 'get_sigmas'
```

### Cause

ComfyUI core migrated its scheduler nodes to the V3 schema, where the entry point is `execute()`.

`AlignYourStepsScheduler` kept a backward-compatible `get_sigmas()` shim:

```python
def get_sigmas(self, model_type, steps, denoise):
    # Deprecated: use the V3 schema's `execute` method instead of this.
    return AlignYourStepsScheduler().execute(model_type, steps, denoise).result
```

`GITSScheduler` did **not** — it only defines `execute()`. That asymmetry is why GITS crashes while AYS still works.

### Fix

Both call sites in `calculate_sigmas` switch to `execute()`: GITS because it is broken today, AYS because it currently depends on a shim core has explicitly marked deprecated.

Indexing is unchanged. `execute()` returns an `io.NodeOutput`, which defines `__getitem__` returning `self.args[index]`, so `[0]` still yields the sigmas tensor exactly as before.

### Verification

On ComfyUI 0.28.3 / PyTorch 2.11.0+cu130:

```
GITS has get_sigmas: False
AYS  has get_sigmas: True
GITS execute -> NodeOutput -> [0]: Tensor (11,)
AYS  execute -> NodeOutput -> [0]: Tensor (11,)
```

Both return an identically shaped sigmas tensor for `steps=10`, so the AYS line is a no-op today and future-proofs against the shim being removed.

### Prior art

The same core change broke ComfyUI-Impact-Pack (issue #1123), fixed there with the same `.get_sigmas(...)` → `.execute(...)` swap.

### Relationship to #360

#360 also addresses the GITS error, but as part of a much larger refactor that removes the `calculate_sigmas` monkeypatch entirely and restructures sampler dispatch. This PR is a minimal two-line fix for the crash alone, offered as an option if the larger change needs more review time. The two would conflict textually — happy to close this one if #360 is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)